### PR TITLE
replace request.raw_post_data with request.body

### DIFF
--- a/sendgrid_events/views.py
+++ b/sendgrid_events/views.py
@@ -8,5 +8,5 @@ from sendgrid_events.models import Event
 @require_POST
 @csrf_exempt
 def handle_batch_post(request):
-    Event.process_batch(data=request.raw_post_data)
+    Event.process_batch(data=request.body)
     return HttpResponse()


### PR DESCRIPTION
When I tried pip installing and using django-sendgrid-events, I got this error:

Internal Server Error: /api/v1/sendgrid/44667e6d-17cd-4e36-bef9-d26d52f280d2/batch/
Traceback (most recent call last):
  File "/Users/rpetty/Dropbox/dev/projects/tribute/venv/lib/python2.7/site-packages/django/core/handlers/base.py", line 111, in get_response
    response = wrapped_callback(request, _callback_args, *_callback_kwargs)
  File "/Users/rpetty/Dropbox/dev/projects/tribute/venv/lib/python2.7/site-packages/django/views/decorators/http.py", line 41, in inner
    return func(request, _args, *_kwargs)
  File "/Users/rpetty/Dropbox/dev/projects/tribute/venv/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 57, in wrapped_view
    return view_func(_args, *_kwargs)
  File "/Users/rpetty/Dropbox/dev/projects/tribute/venv/lib/python2.7/site-packages/sendgrid_events/views.py", line 11, in handle_batch_post
    Event.process_batch(data=request.raw_post_data)
AttributeError: 'WSGIRequest' object has no attribute 'raw_post_data'

It appears changing request.raw_post_data to request.body solves the issue
