### PR TITLE
Celery / Background processing support for django-sendgrid-events

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,25 @@ Documentation
 
 Documentation can be found online at http://django-sendgrid-events.rtfd.org.
 
+How to Use with Celery
+----------------------
+1. In the root of your project, create a sendgrid_event_hooks.py file
+https://gist.github.com/rorito/1f2add7742dcd3449021
+
+2. In settings.py (or equivalent), add:
+```SENDGRID_EVENT_HANDLER = 'tribute.sendgrid_event_hooks.CustomEventHandler'```
+
+3. Wherever you have integrated django-sendgrid-events processing in your app (for example in your tasks.py), add the following:
+```
+from django.core.serializers import serialize
+from sendgrid_events.models import Event
+
+@shared_task
+def process_sendgrid_events(data):
+    events = Event.process_batch(data=data)
+    return json.loads(serialize('json', events))
+```
+
 
 Commercial Support
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -27,25 +27,26 @@ Documentation
 
 Documentation can be found online at http://django-sendgrid-events.rtfd.org.
 
+
 How to Use with Celery
 ----------------------
 1. In the root of your project, create a sendgrid_event_hooks.py file
 https://gist.github.com/rorito/1f2add7742dcd3449021
 
 2. In settings.py (or equivalent), add:
-```SENDGRID_EVENT_HANDLER = 'tribute.sendgrid_event_hooks.CustomEventHandler'```
+.. code-block:: python
+    SENDGRID_EVENT_HANDLER = 'tribute.sendgrid_event_hooks.CustomEventHandler'
 
 3. Wherever you have integrated django-sendgrid-events processing in your app (for example in your tasks.py), add the following:
-```
-from django.core.serializers import serialize
-from sendgrid_events.models import Event
+.. code-block:: python
+    from django.core.serializers import serialize
+    from sendgrid_events.models import Event
 
-@shared_task
-def process_sendgrid_events(data):
-    events = Event.process_batch(data=data)
-    return json.loads(serialize('json', events))
-```
-
+    @shared_task
+    def process_sendgrid_events(data):
+        events = Event.process_batch(data=data)
+        return json.loads(serialize('json', events))
+        
 
 Commercial Support
 ------------------

--- a/sendgrid_events/admin.py
+++ b/sendgrid_events/admin.py
@@ -1,6 +1,34 @@
 from django.contrib import admin
+from django.utils.html import format_html
+from post_office.models import Email
 
 from .models import Event
 
 
-admin.site.register(Event, list_display=["kind", "email", "created_at"], list_filter=["created_at", "kind"], search_fields=["email", "data"])
+class EventAdmin(admin.ModelAdmin):
+    list_display = ["kind", "email", "created_at", "post_office_email"]
+    list_filter = ["created_at", "kind"]
+    search_fields = ["email", "data"]
+
+    def post_office_email(self, obj):
+        try:
+            # Search the email_uuid field from event
+            email_uuid = obj.data["email_uuid"]
+            # Search the Emails with that uuid
+            pks = Email.objects.filter(headers__contains=email_uuid).values_list("pk", flat=True)
+        except KeyError as err:
+            # The event does not have an email_uuid field
+            pks = []
+
+        value = ""
+        if len(pks) > 0:
+            for pk in pks:
+                value += format_html('<strong><a href="/admin/post_office/email/{0}/">{0}</a></strong> ', pk)
+        else:
+            value = "Email object related by email_uuid not found"
+        return value
+
+    post_office_email.allow_tags = True
+
+
+admin.site.register(Event, EventAdmin)

--- a/sendgrid_events/handlers.py
+++ b/sendgrid_events/handlers.py
@@ -1,0 +1,13 @@
+from .models import Event
+
+
+class AbstractEventHandler(object):
+    def process_events(self, data):
+        raise NotImplementedError(
+            'Event handler has to implement method `handle_event`'
+        )
+
+
+class DefaultEventHandler(AbstractEventHandler):
+    def process_events(self, data):
+        return Event.process_batch(data=data)

--- a/sendgrid_events/models.py
+++ b/sendgrid_events/models.py
@@ -1,9 +1,11 @@
+from __future__ import absolute_import
 import json
 
 from django.db import models
 from django.utils import timezone
 
 from jsonfield import JSONField
+from celery import shared_task
 
 from sendgrid_events.signals import batch_processed
 
@@ -25,3 +27,8 @@ class Event(models.Model):
             ))
         batch_processed.send(sender=Event, events=events)
         return events
+
+
+@shared_task
+def process_batch(data):
+    return Event.process_batch(data=data)

--- a/sendgrid_events/views.py
+++ b/sendgrid_events/views.py
@@ -20,11 +20,19 @@ def handle_batch_post(request):
     if background_process:
         if queue:
             process_batch.apply_async(
-                kwargs={'data': request.body},
+                kwargs={
+                    'data': request.body,
+                    'json_compatible': True
+                },
                 queue=queue
             )
         else:
-            process_batch.apply_async(kwargs={'data': request.body})
+            process_batch.apply_async(
+                kwargs={
+                    'data': request.body,
+                    'json_compatible': True
+                }
+            )
 
     else:
         Event.process_batch(data=request.body)

--- a/sendgrid_events/views.py
+++ b/sendgrid_events/views.py
@@ -1,12 +1,31 @@
+from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from sendgrid_events.models import Event
+from sendgrid_events.models import Event, process_batch
 
 
 @require_POST
 @csrf_exempt
 def handle_batch_post(request):
-    Event.process_batch(data=request.body)
+    background_process = False
+    if hasattr(settings, 'SENDGRID_BACKGROUND_PROCESSING'):
+        background_process = settings.SENDGRID_BACKGROUND_PROCESSING
+
+    queue = None
+    if hasattr(settings, 'SENDGRID_BACKGROUND_QUEUE'):
+        queue = settings.SENDGRID_BACKGROUND_QUEUE
+
+    if background_process:
+        if queue:
+            process_batch.apply_async(
+                kwargs={'data': request.body},
+                queue=queue
+            )
+        else:
+            process_batch.apply_async(kwargs={'data': request.body})
+
+    else:
+        Event.process_batch(data=request.body)
     return HttpResponse()


### PR DESCRIPTION
Hi Patrick, we've been using django-sendgrid-events on https://www.tribute.co with good success. One thing we recently added in our fork was a quick check for some settings vars to enable background processing via celery workers. We use Heroku, so it frees up our web dynos for quicker request/response cycles and performs the work on a background worker. Anyways, here's a PR if you're interested : )
